### PR TITLE
Potential fix for code scanning alert no. 20: Uncontrolled data used in path expression

### DIFF
--- a/src/dash.py
+++ b/src/dash.py
@@ -297,9 +297,10 @@ class Handler(http.server.SimpleHTTPRequestHandler):
             if len(path) >= 2:
                 filename = "/".join(path[1:])
                 timelapses_dir = os.path.join(os.path.dirname(dash_config.output), "timelapses")
-                timelapse_path = os.path.join(timelapses_dir, filename)
-                
-                if os.path.isfile(timelapse_path) and self.is_safe_path(timelapse_path):
+                timelapse_path = os.path.normpath(os.path.join(timelapses_dir, filename))
+                # Ensure the normalized path is within the timelapses_dir
+                if (os.path.isfile(timelapse_path)
+                    and os.path.commonpath([timelapse_path, timelapses_dir]) == timelapses_dir):
                     mime = mimetypes.guess_type(timelapse_path)[0] or 'application/octet-stream'
                     content = open(timelapse_path, 'rb').read()
                 else:


### PR DESCRIPTION
Potential fix for [https://github.com/Zalgar/xrit-rx-docker/security/code-scanning/20](https://github.com/Zalgar/xrit-rx-docker/security/code-scanning/20)

To fix the uncontrolled path expression, we should ensure that any file path constructed from user input is normalized and checked to be contained within the intended directory (`timelapses_dir`). This can be done by using `os.path.normpath` to normalize the path, and then verifying that the resulting path starts with the intended directory. This prevents directory traversal attacks. The fix should be applied in the region where `timelapse_path` is constructed and used (lines 298–304). We should also ensure that the normalization and containment check are performed before calling `os.path.isfile` and `open`. If `self.is_safe_path` is meant to do this, we should replace or supplement it with a robust check.

**Required changes:**
- Normalize `timelapse_path` using `os.path.normpath`.
- Check that the normalized path starts with `timelapses_dir` (using `os.path.commonpath` or string comparison).
- Only proceed to serve the file if the check passes.
- Optionally, update or replace the use of `self.is_safe_path` to use this robust check.

No new imports are needed, as `os.path` is already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
